### PR TITLE
Reduce Necessary Testing Boilerplate

### DIFF
--- a/.storybook/__conf__/mochaMockConfig.js
+++ b/.storybook/__conf__/mochaMockConfig.js
@@ -1,14 +1,8 @@
-import {storiesOf, action, linkTo, specs, describe, it,} from "../__mocks__/facade-mocha";
+import {storiesOf, action, linkTo, specs} from "../__mocks__/facade-mocha";
 global.storiesOf = storiesOf;
 global.action = action;
 global.linkTo = linkTo;
 global.specs = specs;
-global.describe = describe;
-global.it = it;
-global.after = after;
-global.before = before;
-global.beforeEach = beforeEach;
-global.afterEach = afterEach;
 
 import { jsdom } from 'jsdom';
 

--- a/.storybook/__mocks__/facade-mocha.js
+++ b/.storybook/__mocks__/facade-mocha.js
@@ -1,26 +1,2 @@
-export const storiesOf = function storiesOf() {
-  var api = {};
-  api.add = (name, func)=> {
-    func();
-    return api;
-  };
-  api.addWithInfo = (name, func)=> {
-    func();
-    return api;
-  };
-  return api;
-};
-export const action = () => {};
-
-export const linkTo = () => {};
-
-export const specs = (spec) => {
-  spec();
-};
-
-export const describe = describe;
-export const it = it;
-export const after = after;
-export const before = before;
-export const afterEach = afterEach;
-export const beforeEach = beforeEach;
+const { mocks } = require('../../src');
+module.exports = { ...mocks };

--- a/.storybook/__mocks__/facade.js
+++ b/.storybook/__mocks__/facade.js
@@ -1,41 +1,5 @@
-export const storiesOf = function storiesOf() {
-  var api = {};
-  var story;
-  api.add = (name, func)=> {
-    story = func();
-    snapshot(name, story);
-    return api;
-  };
-  api.addWithInfo = (name, func)=> {
-    story = func();
-    snapshot(name, story);
-    return api;
-  };
-  return api;
+const { mocks } = require('../../src');
+module.exports = {
+  ...mocks,
+  storiesOf: mocks.snapshotStoriesOf,
 };
-export const action = () => {};
-
-export const linkTo = () => {};
-
-export const specs = (spec) => {
-  spec()
-};
-
-export const snapshot = (name, story) => {
-    it(name, function () {
-      let renderer = require("react-test-renderer");
-      const tree = renderer.create(story).toJSON();
-      expect(tree).toMatchSnapshot();
-    });
-};
-
-export const describe = jasmine.currentEnv_.describe;
-export const it = jasmine.currentEnv_.it;
-export const beforeEach = jasmine.currentEnv_.beforeEach;
-export const afterEach = jasmine.currentEnv_.afterEach;
-export const xit = jasmine.currentEnv_.xit;
-export const xdescribe = jasmine.currentEnv_.xdescribe;
-export const fit = jasmine.currentEnv_.fit;
-export const after = () => {};
-export const before = () => {};
-

--- a/.storybook/__tests__/__snapshots__/sample.ci.jest.stories.js.snap
+++ b/.storybook/__tests__/__snapshots__/sample.ci.jest.stories.js.snap
@@ -11,3 +11,10 @@ exports[`test Hello World 1`] = `
   Hello World
 </button>
 `;
+
+exports[`test Hello World Streamlined 1`] = `
+<button
+  onClick={undefined}>
+  Hello World
+</button>
+`;

--- a/.storybook/__tests__/__snapshots__/sample.ci.jest.stories.js.snap
+++ b/.storybook/__tests__/__snapshots__/sample.ci.jest.stories.js.snap
@@ -1,20 +1,20 @@
 exports[`test Hello Earth 1`] = `
 <button
-  onClick={undefined}>
+  onClick={[Function NO_FUNC]}>
   Hello Earth
 </button>
 `;
 
 exports[`test Hello World 1`] = `
 <button
-  onClick={undefined}>
+  onClick={[Function NO_FUNC]}>
   Hello World
 </button>
 `;
 
 exports[`test Hello World Streamlined 1`] = `
 <button
-  onClick={undefined}>
+  onClick={[Function NO_FUNC]}>
   Hello World
 </button>
 `;

--- a/.storybook/__tests__/sample.ci.jest.stories.js
+++ b/.storybook/__tests__/sample.ci.jest.stories.js
@@ -37,6 +37,36 @@ stories.add('Hello World', function () {
   return helloWorldStory;
 });
 
+stories.add('Hello World Streamlined', function () {
+  const helloWorldStory =
+    <button onClick={action('Hello World')}>
+      Hello World
+    </button>;
+
+  describe('Hello World Streamlined', function () {
+    let output;
+    beforeEach(function() {
+      console.log('BEFORE EACH');
+      output = mount(helloWorldStory);
+    });
+
+    afterEach(function() {
+      console.log('AFTER EACH');
+    });
+
+    it('Should have the Hello World label', function () {
+      expect(output.text()).toContain('Hello World');
+    });
+
+    it('Should have the Hello World label', function () {
+      expect(output.text()).toContain('Hello World');
+    });
+  });
+
+  return helloWorldStory;
+});
+
+
 stories.add('Hello Earth', function () {
   const helloEarthStory =
     <button onClick={action('Hello Earth')}>

--- a/.storybook/__tests__/sample.ci.jest.stories.js
+++ b/.storybook/__tests__/sample.ci.jest.stories.js
@@ -1,7 +1,5 @@
 import React from "react";
-import {storiesOf, action, describe, it, specs,
-beforeEach, before, after, afterEach, xdescribe,
-fit, xit} from "../facade";
+import {storiesOf, action, specs} from "../facade";
 import {mount} from "enzyme";
 import expect from "expect";
 

--- a/.storybook/__tests__/sample.ci.mocha.stories.js
+++ b/.storybook/__tests__/sample.ci.mocha.stories.js
@@ -41,6 +41,44 @@ stories.add('Hello World', function () {
   return helloWorldStory;
 });
 
+stories.add('Hello World Streamlined', function () {
+  const helloWorldStory =
+    <button onClick={action('Hello World')}>
+      Hello World
+    </button>;
+
+  describe('Hello World Streamlined', function () {
+    let output;
+    beforeEach(function() {
+      console.log('BEFORE EACH');
+      output = mount(helloWorldStory);
+    });
+
+    before(function() {
+      console.log('BEFORE');
+    });
+
+    afterEach(function() {
+      console.log('AFTER EACH');
+    });
+
+    after(function() {
+      console.log('AFTER ');
+    });
+
+    it('Should have the Hello World label', function () {
+      expect(output.text()).toContain('Hello World');
+    });
+
+    it('Should have the Hello World label', function () {
+      expect(output.text()).toContain('Hello World');
+    });
+  });
+
+  return helloWorldStory;
+});
+
+
 stories.add('Hello Earth', function () {
   const helloEarthStory =
     <button onClick={action('Hello Earth')}>

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ stories.add('Hello World', function () {
       Hello World
     </button>;
 
-  specs(() => describe('Hello World', function () {
+  describe('Hello World', function () {
     it('Should have the Hello World label', function () {
       let output = mount(story);
       expect(output.text()).toContain('Hello World');
     });
-  }));
+  });
 
   return story;
 });
@@ -83,7 +83,7 @@ Writing tests directly next to the component declaration used for the story is a
 To do that, the idea is to add to the test runner, all the files used for declaring stories.
 But because this addon redefine describe and it functions, you'll need some extra-configuration to make the tests pass within the test runner.
 
-This repository has a [directory full of examples](https://github.com/mthuret/storybook-addon-specifications/tree/master/.storybook) where you can find everything that is describe here. 
+This repository has a [directory full of examples](https://github.com/mthuret/storybook-addon-specifications/tree/master/.storybook) where you can find everything that is describe here.
 
 ### Using JEST
 
@@ -217,7 +217,7 @@ If for any reason you want to choose when to snapshot a story, that's also possi
 ```js
 export const snapshot = () => {};
 ```
-When storybook is going to run, it will do nothing with the snapshot function. 
+When storybook is going to run, it will do nothing with the snapshot function.
 
 ### Using Mocha
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,19 @@ stories.add('Hello World', function () {
 
 > Note : if you use enzyme, you will need to add the following lines to your webpack.config.js file. You also needs to add the **json library** to your dev dependencies.
 
->```
->externals: {
->    'jsdom': 'window',
->    'cheerio': 'window',
->    'react/lib/ExecutionEnvironment': true,
->    'react/lib/ReactContext': 'window',
->    'react/addons': true,
->  }
->```
+```js
+const specs = require('storybook-addon-specifications/dist/webpack.config');
+
+module.exports = {
+  < your config >
+  module: {
+    loaders: [
+      specs.testMethodLoader,
+    ],
+  },
+  externals: spec.externals,
+}
+```
 
 You can use `beforeEach, before, after and afterEach` functions to mutualize or clean up some stuff.
 

--- a/dist/components/Specifications/index.js
+++ b/dist/components/Specifications/index.js
@@ -1,0 +1,78 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _aphrodite = require("aphrodite");
+
+var _style = require("./style");
+
+var _style2 = _interopRequireDefault(_style);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Specifications = function (_Component) {
+  _inherits(Specifications, _Component);
+
+  function Specifications() {
+    _classCallCheck(this, Specifications);
+
+    return _possibleConstructorReturn(this, (Specifications.__proto__ || Object.getPrototypeOf(Specifications)).apply(this, arguments));
+  }
+
+  _createClass(Specifications, [{
+    key: "render",
+    value: function render() {
+      var results = this.props.results;
+
+      return _react2.default.createElement(
+        "ul",
+        { className: (0, _aphrodite.css)(_style2.default.wrapper) },
+        results.wrongResults.map(function (r, idx) {
+          return _react2.default.createElement(
+            "li",
+            { className: (0, _aphrodite.css)(_style2.default.error, _style2.default.li), key: idx },
+            _react2.default.createElement(
+              "p",
+              null,
+              r.spec
+            ),
+            _react2.default.createElement(
+              "p",
+              { className: (0, _aphrodite.css)(_style2.default.message) },
+              r.message
+            )
+          );
+        }),
+        results.goodResults.map(function (r, idx) {
+          return _react2.default.createElement(
+            "li",
+            { className: (0, _aphrodite.css)(_style2.default.pass, _style2.default.li), key: idx },
+            _react2.default.createElement(
+              "p",
+              null,
+              r
+            )
+          );
+        })
+      );
+    }
+  }]);
+
+  return Specifications;
+}(_react.Component);
+
+exports.default = Specifications;

--- a/dist/components/Specifications/style.js
+++ b/dist/components/Specifications/style.js
@@ -1,0 +1,54 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _aphrodite = require('aphrodite');
+
+exports.default = _aphrodite.StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    fontFamily: '-apple-system, ".SFNSText-Regular", "San Francisco", Roboto, "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif',
+    color: 'rgb(68, 68, 68)',
+    fontSize: 12,
+    letterSpacing: 1,
+    textDecoration: 'none',
+    listStyleType: 'none'
+  },
+  error: {
+    ':before': {
+      content: "'✘'",
+      padding: '3px 5px',
+      backgroundColor: 'red'
+    }
+  },
+
+  li: {
+    ':before': {
+      marginRight: '5px',
+      marginTop: '11px',
+      fontSize: '70%',
+      color: 'white',
+      fontWeight: 'bold',
+      borderRadius: '12px',
+      float: 'left'
+    }
+  },
+
+  message: {
+    backgroundColor: 'rgb(250, 250, 250)',
+    padding: '10px',
+    margin: '10px'
+  },
+
+  pass: {
+    ':before': {
+      content: "'✔'",
+      padding: '4px 5px',
+      backgroundColor: 'green'
+    }
+  }
+});

--- a/dist/containers/Specifications/index.js
+++ b/dist/containers/Specifications/index.js
@@ -1,0 +1,74 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _Specifications = require("../../components/Specifications/");
+
+var _Specifications2 = _interopRequireDefault(_Specifications);
+
+var _ = require("../../");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Specifications = function (_Component) {
+  _inherits(Specifications, _Component);
+
+  function Specifications(props) {
+    var _ref;
+
+    _classCallCheck(this, Specifications);
+
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var _this = _possibleConstructorReturn(this, (_ref = Specifications.__proto__ || Object.getPrototypeOf(Specifications)).call.apply(_ref, [this, props].concat(args)));
+
+    _this.state = { results: { wrongResults: [], goodResults: [] } };
+    _this._listener = function (d) {
+      return _this.setState({ results: d.results });
+    };
+    return _this;
+  }
+
+  _createClass(Specifications, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      var _this2 = this;
+
+      this.props.channel.on(_.EVENT_ID, this._listener);
+      this.props.api.onStory(function (data) {
+        _this2.setState({ results: { wrongResults: [], goodResults: [] } });
+      });
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      this.props.channel.removeListener(_.EVENT_ID, this._listener);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var results = this.state.results;
+      return _react2.default.createElement(_Specifications2.default, { results: results });
+    }
+  }]);
+
+  return Specifications;
+}(_react.Component);
+
+exports.default = Specifications;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.mocks = exports.xdescribe = exports.fit = exports.xit = exports.before = exports.after = exports.afterEach = exports.beforeEach = exports.it = exports.describe = exports.specs = exports.register = exports.EVENT_ID = exports.PANEL_ID = exports.ADDON_ID = undefined;
 
 var _manager = require('./manager');
 
@@ -75,7 +76,16 @@ Object.defineProperty(exports, 'xdescribe', {
     return _preview.xdescribe;
   }
 });
+
+var _mocks2 = require('./mocks');
+
+var _mocks = _interopRequireWildcard(_mocks2);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 // addons, panels and events get unique names using a prefix
 var ADDON_ID = exports.ADDON_ID = 'storybook-addon-specifications';
 var PANEL_ID = exports.PANEL_ID = ADDON_ID + '/specifications-panel';
 var EVENT_ID = exports.EVENT_ID = ADDON_ID + '/specifications-event';
+
+exports.mocks = _mocks;

--- a/dist/mocks.js
+++ b/dist/mocks.js
@@ -1,0 +1,58 @@
+"use strict";
+
+var NO_FUNC = function NO_FUNC() {};
+
+var snapshotStoriesOf = function snapshotStoriesOf() {
+  var story = void 0;
+  var api = {
+    add: function add(name, func) {
+      story = func();
+      snapshot(name, story);
+      return api;
+    },
+    addWithInfo: function addWithInfo(name, func) {
+      story = func();
+      snapshot(name, story);
+      return api;
+    }
+  };
+  return api;
+};
+var storiesOf = function storiesOf() {
+  var api = {
+    add: function add(name, func) {
+      func();
+      return api;
+    },
+    addWithInfo: function addWithInfo(name, func) {
+      func();
+      return api;
+    }
+  };
+  return api;
+};
+
+var action = function action() {
+  return NO_FUNC;
+};
+var linkTo = NO_FUNC;
+var specs = function specs(spec) {
+  return spec();
+};
+
+var snapshot = function snapshot(name, story) {
+  it(name, function () {
+    var renderer = require("react-test-renderer");
+    var tree = renderer.create(story).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+};
+
+module.exports = {
+  snapshotStoriesOf: snapshotStoriesOf,
+  storiesOf: storiesOf,
+  action: action,
+  linkTo: linkTo,
+  specs: specs,
+  snapshot: snapshot
+};

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -21,9 +21,7 @@ var afterFunc = {};
 var afterEachFunc = {};
 
 function specs(specs) {
-  var storyName = specs();
-  var channel = _storybookAddons2.default.getChannel();
-  channel.emit(_.EVENT_ID, { results: results[storyName] });
+  // Do nothing, keep this function around for back-compat
 }
 
 var describe = exports.describe = function describe(storyName, func) {
@@ -37,6 +35,8 @@ var describe = exports.describe = function describe(storyName, func) {
 
   if (afterFunc[currentStory]) afterFunc[currentStory]();
 
+  var channel = _storybookAddons2.default.getChannel();
+  channel.emit(_.EVENT_ID, { results: results[storyName] });
   return storyName;
 };
 
@@ -46,7 +46,7 @@ var it = exports.it = function it(desc, func) {
     func();
     results[currentStory].goodResults.push(desc);
   } catch (e) {
-    console.error(currentStory + ' - ' + desc + ' : ' + e);
+    console.error(currentStory + ' - ' + desc + ' : ' + e, e.stack);
     results[currentStory].wrongResults.push({ spec: desc, message: e.message });
   }
   if (afterEachFunc[currentStory]) afterEachFunc[currentStory]();

--- a/dist/webpack.config.js
+++ b/dist/webpack.config.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var methods = ['specs', 'describe', 'it', 'beforeEach', 'afterEach', 'after', 'before', 'xit', 'fit', 'xdescribe'];
+
+module.exports = {
+  module: {
+    loaders: [{
+      test: require.resolve('./'),
+      loader: 'expose-members?' + methods.join(',')
+    }]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "chai": "^3.5.0",
     "enzyme": "^2.4.1",
     "expect": "^1.20.2",
-    "expose-members-loader": "0.0.3",
     "jest": "^14.1.0",
     "json": "^9.0.4",
     "react": "^15.3.0",
@@ -46,7 +45,8 @@
     "shelljs": "^0.7.3"
   },
   "dependencies": {
-    "aphrodite": "^0.5.0"
+    "aphrodite": "^0.5.0",
+    "expose-members-loader": "0.0.3"
   },
   "peerDependencies": {
     "@kadira/storybook-addons": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chai": "^3.5.0",
     "enzyme": "^2.4.1",
     "expect": "^1.20.2",
+    "expose-members-loader": "0.0.3",
     "jest": "^14.1.0",
     "json": "^9.0.4",
     "react": "^15.3.0",

--- a/register.js
+++ b/register.js
@@ -1,1 +1,1 @@
-require('./dist').register();
+require('./dist/manager').register();

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@ export { register } from './manager';
 export { specs, describe, it,
   beforeEach, afterEach, after, before,
 xit, fit, xdescribe} from './preview';
+export * as mocks from './mocks';

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -1,0 +1,52 @@
+const NO_FUNC = () => {};
+
+const snapshotStoriesOf = function snapshotStoriesOf() {
+  let story;
+  const api = {
+    add(name, func) {
+      story = func();
+      snapshot(name, story);
+      return api;
+    },
+    addWithInfo(name, func) {
+      story = func();
+      snapshot(name, story);
+      return api;
+    },
+  };
+  return api;
+};
+const storiesOf = function storiesOf() {
+  const api = {
+    add(name, func) {
+      func();
+      return api;
+    },
+    addWithInfo(name, func) {
+      func();
+      return api;
+    },
+  };
+  return api;
+};
+
+const action = () => NO_FUNC;
+const linkTo = NO_FUNC;
+const specs = spec => spec();
+
+const snapshot = (name, story) => {
+    it(name, function () {
+      const renderer = require("react-test-renderer");
+      const tree = renderer.create(story).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+};
+
+module.exports = {
+  snapshotStoriesOf,
+  storiesOf,
+  action,
+  linkTo,
+  specs,
+  snapshot,
+};

--- a/src/preview.js
+++ b/src/preview.js
@@ -33,7 +33,7 @@ export const it = function (desc, func) {
     func();
     results[currentStory].goodResults.push(desc);
   } catch (e) {
-    console.error(`${currentStory} - ${desc} : ${e}`);
+    console.error(`${currentStory} - ${desc} : ${e}`, e.stack);
     results[currentStory].wrongResults.push({spec: desc, message: e.message});
   }
   if(afterEachFunc[currentStory]) afterEachFunc[currentStory]();

--- a/src/preview.js
+++ b/src/preview.js
@@ -8,9 +8,7 @@ const afterFunc = {};
 const afterEachFunc = {};
 
 export function specs(specs) {
-  let storyName = specs();
-  const channel = addons.getChannel();
-  channel.emit(EVENT_ID, {results : results[storyName]});
+  // Do nothing, keep this function around for back-compat
 }
 
 export const describe = (storyName, func) => {
@@ -24,6 +22,8 @@ export const describe = (storyName, func) => {
 
   if(afterFunc[currentStory]) afterFunc[currentStory]();
 
+  const channel = addons.getChannel();
+  channel.emit(EVENT_ID, {results : results[storyName]});
   return storyName;
 };
 

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -11,13 +11,15 @@ const methods = [
   'xdescribe',
 ];
 
-module.exports = {
-  module: {
-    loaders: [
-      {
-        test: require.resolve('./'),
-        loader: `expose-members?${methods.join(',')}`,
-      },
-    ],
-  },
+export const externals = {
+  'jsdom': 'window',
+  'cheerio': 'window',
+  'react/lib/ExecutionEnvironment': true,
+  'react/lib/ReactContext': 'window',
+  'react/addons': true,
+};
+
+export const testMethodLoader = {
+  test: require.resolve('./'),
+  loader: `expose-members?${methods.join(',')}`,
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -1,0 +1,23 @@
+const methods = [
+  'specs',
+  'describe',
+  'it',
+  'beforeEach',
+  'afterEach',
+  'after',
+  'before',
+  'xit',
+  'fit',
+  'xdescribe',
+];
+
+module.exports = {
+  module: {
+    loaders: [
+      {
+        test: require.resolve('./'),
+        loader: `expose-members?${methods.join(',')}`,
+      },
+    ],
+  },
+};


### PR DESCRIPTION
This pull request reduces the amount of scaffolding required to get tests up and running within a story. Instead of requiring a user to nest their `describe()` functions under specs(), they can just run describe() within the story.

There are two ideas here:
1) Remove the requirement to have a `specs()` function.
2) Establish a common mock implementation of the storybook API for CI test runners to use