### PR TITLE
Fixing issue where upon completion of async Mocha tests the specifications panel re-renders with new results regardless of the current story in Storybook

### DIFF
--- a/src/containers/Specifications/index.js
+++ b/src/containers/Specifications/index.js
@@ -6,15 +6,21 @@ import {EVENT_ID} from "../../";
 export default class Specifications extends Component {
   constructor(props, ...args) {
     super(props, ...args);
-    this.state = {results: {wrongResults: [], goodResults: []}};
-    this._listener = d => this.setState({results: d.results});
+    this.state = { storyName: null, results: { wrongResults: [], goodResults: [] } };
+    this._listener = ({ asyncResultsUpdate, storyName, results }) => {
+      if (asyncResultsUpdate) {
+        if (storyName === this.state.storyName) {
+          this.setState({ results });
+        }
+      } else {
+        this.setState({ storyName, results });
+      }
+    }
   }
 
   componentDidMount() {
     this.props.channel.on(EVENT_ID, this._listener);
-    this.props.api.onStory((data) => {
-      this.setState({ results: { wrongResults: [], goodResults: [] } });
-    });
+    this.props.api.onStory((data) => this.setState({ storyName: null, results: { wrongResults: [], goodResults: [] } }));
   }
 
   componentWillUnmount() {
@@ -23,6 +29,6 @@ export default class Specifications extends Component {
 
   render() {
     const results = this.state.results;
-    return <SpecificationsComponent results={results}/>;
+    return <SpecificationsComponent results={results} />;
   }
 }

--- a/src/preview.js
+++ b/src/preview.js
@@ -10,20 +10,14 @@ const afterEachFunc = {};
 export function specs(specs) {
   let storyName = specs();
   const channel = addons.getChannel();
-  channel.emit(EVENT_ID, {results : results[storyName]});
+  channel.emit(EVENT_ID, { storyName, results: results[storyName] });
 }
 
 export const describe = (storyName, func) => {
   currentStory = storyName;
-  results[currentStory] = {
-    goodResults: [],
-    wrongResults: []
-  };
-
+  results[currentStory] = { goodResults: [], wrongResults: [] };
   func();
-
   if(afterFunc[currentStory]) afterFunc[currentStory]();
-
   return storyName;
 };
 
@@ -39,15 +33,15 @@ export const it = function(desc, func) {
     results[storyName].wrongResults.push({ spec: desc, message: e.message });
   };
 
-  const emitUpdate = () => {
+  const emitAsyncResultsUpdate = () => {
     const channel = addons.getChannel();
-    channel.emit(EVENT_ID, { results: results[storyName] });
+    channel.emit(EVENT_ID, { asyncResultsUpdate: true, storyName, results: results[storyName] });
   };
 
   const done = (e) => {
     if (e) pushWrongResult(e);
     else pushGoodResult();
-    emitUpdate();
+    emitAsyncResultsUpdate();
   };
 
   if (beforeEachFunc[storyName]) beforeEachFunc[storyName]();


### PR DESCRIPTION
This pull request aims to finish what was started in https://github.com/mthuret/storybook-addon-specifications/pull/47 by fixing a bug where the specifications panel always renders the results of the last component with asynchronous mocha tests on the initial load of a Storybook instance.

Let's say you have three components with stories and tests - A, B, and C. And let's say that component B has an asynchronous test. The current behavior is such that if you open a new tab in your web browser and initially land on either component A or component C, the test results of component B will show up in the specifications panel.

This bug exists because the specifications panel re-renders regardless of the current story in Storybook upon the completion of an asynchronous test.

Please let me know your thoughts on my proposed solution. Thank you!