### PR TITLE
Promise-based async interface

### DIFF
--- a/.storybook/__tests__/sample.ci.jest.stories.js
+++ b/.storybook/__tests__/sample.ci.jest.stories.js
@@ -29,7 +29,12 @@ stories.add('Hello World', function () {
       expect(output.text()).toContain('Hello World');
     });
 
-    it('Should have the Hello World label', function () {
+    it('Should have the Hello World label', function (done) {
+      expect(output.text()).toContain('Hello World');
+      done();
+    });
+
+    it('Should have the Hello World label', async function () {
       expect(output.text()).toContain('Hello World');
     });
 

--- a/.storybook/__tests__/sample.ci.mocha.stories.js
+++ b/.storybook/__tests__/sample.ci.mocha.stories.js
@@ -33,7 +33,12 @@ stories.add('Hello World', function () {
       expect(output.text()).toContain('Hello World');
     });
 
-    it('Should have the Hello World label', function () {
+    it('Should have the Hello World label', function (done) {
+      expect(output.text()).toContain('Hello World');
+      done();
+    });
+
+    it('Should have the Hello World label', async function () {
       expect(output.text()).toContain('Hello World');
     });
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,38 @@ stories.add('Hello World', function () {
       let output = mount(story);
       expect(output.text()).toContain('Hello World');
     });
+
+    // Asynchronous example using `done` syntax
+
+    it('Should have the Hello World label', function (done) {
+      let output = mount(story);
+      setTimeout(function() {
+        try {
+          expect(output.text()).toContain('Hello World');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+    });
+
+    // Asynchronous example using returned Promise,
+    // assuming a Promise implementation is available,
+    // also permits async/await where supported
+
+    it('Should have the Hello World label', function () {
+      let output = mount(story);
+      return new Promise(function(resolve, reject) {
+        setTimeout(function() {
+          try {
+            expect(output.text()).toContain('Hello World');
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        })
+      });
+    });
   }));
 
   return story;
@@ -70,7 +102,7 @@ You can use `beforeEach`, `before`, `after` and `afterEach` functions to mutuali
 
 ## Using enzyme
 
-To use enzyme inside storybooks, you will need to do the following: 
+To use enzyme inside storybooks, you will need to do the following:
 
 1. Configure enzyme with an appropriate adapter inside your .storybook/config.js:
    ```js
@@ -100,7 +132,7 @@ Writing tests directly next to the component declaration used for the story is a
 To do that, the idea is to add to the test runner, all the files used for declaring stories.
 But because this addon redefine describe and it functions, you'll need some extra-configuration to make the tests pass within the test runner.
 
-This repository has a [directory full of examples](https://github.com/mthuret/storybook-addon-specifications/tree/master/.storybook) where you can find everything that is describe here. 
+This repository has a [directory full of examples](https://github.com/mthuret/storybook-addon-specifications/tree/master/.storybook) where you can find everything that is describe here.
 
 ### Using Jest
 
@@ -234,7 +266,7 @@ If for any reason you want to choose when to snapshot a story, that's also possi
 ```js
 export const snapshot = () => {};
 ```
-When storybook is going to run, it will do nothing with the snapshot function. 
+When storybook is going to run, it will do nothing with the snapshot function.
 
 ### Using Mocha
 
@@ -313,7 +345,7 @@ complexe in order to be able to use jsdom.
 >```js
 > // choose one of the following
 > import { jsdom } from 'jsdom'; // older versions of JSDOM
-> import { JSDOM } from 'jsdom'; // newer version 
+> import { JSDOM } from 'jsdom'; // newer version
 >/**
 > *Mocking browser-like DOM
 > */
@@ -343,7 +375,7 @@ complexe in order to be able to use jsdom.
 >global.navigator = global.window.navigator;
 >```
 
-or if you are a newer version of jsdom 
+or if you are a newer version of jsdom
 
 >```js
 >/**
@@ -401,16 +433,16 @@ import Example from './example'
 
 storiesOf('Example', module)
   .add('Default', () => {
-  
+
     // tests are loaded here
     specs(() => tests)
-    
+
     return <Example />
   })
 ```
 
-We must first override the Jest describe/it/expect blocks to use the storybook-addon-spec's implementation. 
-Add the following to your storybook config file. 
+We must first override the Jest describe/it/expect blocks to use the storybook-addon-spec's implementation.
+Add the following to your storybook config file.
 
 /.storybook/config.js
 

--- a/src/preview.js
+++ b/src/preview.js
@@ -49,7 +49,10 @@ export const it = function(desc, func) {
   try {
     if (func.length) func(done);
     else {
-      func();
+      const result = func();
+      if (result && typeof result.then === 'function') {
+        return result.then(() => done(), (e) => done(e || { message: 'failed' }));
+      }
       pushGoodResult();
     }
   } catch (e) {


### PR DESCRIPTION
Code to resolve https://github.com/mthuret/storybook-addon-specifications/issues/105

For the moment the change only applies to `it`, though Jest/Mocha allows it on the before/after hooks too, so that might be some future work.

The check for a returned Promise matches what Mocha does:
https://github.com/mochajs/mocha/blob/master/lib/runnable.js#L373

Nothing in this code actually requires the `Promise` class be available, means the code is compatible with pre-v0.12.18 node, although hardly a requirement to go back that far.

I've updated some tests, though more for illustrative purposes, as those tests will not fail if async doesn't work. I've updated the docs too so users know they can use both the `done` and Promise interfaces.